### PR TITLE
2.0.1 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwindcss",
-  "version": "2.0.1",
+  "version": "2.0.1-compat",
   "description": "A utility-first CSS framework for rapidly building custom user interfaces.",
   "license": "MIT",
   "main": "lib/index.js",

--- a/package.postcss8.json
+++ b/package.postcss8.json
@@ -51,6 +51,10 @@
     "prettier": "^2.1.2",
     "rimraf": "^3.0.0"
   },
+  "peerDependencies": {
+    "autoprefixer": "^10.0.2",
+    "postcss": "^8.0.9"
+  },
   "dependencies": {
     "@fullhuman/postcss-purgecss": "^3.0.0",
     "bytes": "^3.0.0",
@@ -65,15 +69,13 @@
     "node-emoji": "^1.8.1",
     "object-hash": "^2.0.3",
     "postcss-functions": "^3",
-    "postcss-js": "^2",
-    "postcss-nested": "^4",
+    "postcss-js": "^3.0.3",
+    "postcss-nested": "^5.0.1",
     "postcss-selector-parser": "^6.0.4",
     "postcss-value-parser": "^4.1.0",
     "pretty-hrtime": "^1.0.3",
     "reduce-css-calc": "^2.1.6",
-    "resolve": "^1.19.0",
-    "autoprefixer": "^9",
-    "postcss": "^7"
+    "resolve": "^1.19.0"
   },
   "browserslist": [
     "> 1%",

--- a/src/index.postcss8.js
+++ b/src/index.postcss8.js
@@ -2,7 +2,6 @@ import path from 'path'
 import fs from 'fs'
 
 import _ from 'lodash'
-import postcss from 'postcss'
 
 import getModuleDependencies from './lib/getModuleDependencies'
 import registerConfigAsDependency from './lib/registerConfigAsDependency'
@@ -63,7 +62,7 @@ const getConfigFunction = (config) => () => {
   return resolveConfig([...getAllConfigs(configObject)])
 }
 
-const plugin = postcss.plugin('tailwindcss', (config) => {
+module.exports = function (config) {
   const plugins = []
   const resolvedConfigPath = resolveConfigPath(config)
 
@@ -71,11 +70,14 @@ const plugin = postcss.plugin('tailwindcss', (config) => {
     plugins.push(registerConfigAsDependency(resolvedConfigPath))
   }
 
-  return postcss([
-    ...plugins,
-    processTailwindFeatures(getConfigFunction(resolvedConfigPath || config)),
-    formatCSS,
-  ])
-})
+  return {
+    postcssPlugin: 'tailwindcss',
+    plugins: [
+      ...plugins,
+      processTailwindFeatures(getConfigFunction(resolvedConfigPath || config)),
+      formatCSS,
+    ],
+  }
+}
 
-module.exports = plugin
+module.exports.postcss = true


### PR DESCRIPTION
A version of Tailwind's 2.0.1 compatibility tag that uses PostCSS 7 and therefore supports Parcel 1